### PR TITLE
Lock normalizr@2.0.1 to prevent array->object casting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teachers/tpt-connect",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "TpT-Connect is an extension to [Redux](https://github.com/reactjs/redux) which creates a simple interface for components' data fetching.",
   "main": "lib",
   "engines": {
@@ -73,7 +73,7 @@
     "invariant": "^2.0.0",
     "lodash.mergewith": "^4.4.0",
     "normalize-url": "^1.6.0",
-    "normalizr": "^2.0.0",
+    "normalizr": "2.0.1",
     "querystring": "~0.2.0",
     "redux-api-middleware": "git://github.com/teacherspayteachers/redux-api-middleware.git#8eb5e5adee0ba4e7aa6d1008856d62bc539e89cd",
     "string-hash": "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3764,6 +3764,12 @@ normalize-url@^1.4.0, normalize-url@^1.6.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+normalizr@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalizr/-/normalizr-2.0.1.tgz#da0e2c87c25021aa13a7b8c4a9889c705e282a87"
+  dependencies:
+    lodash "^4.0.0"
+
 normalizr@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/normalizr/-/normalizr-2.3.1.tgz#ac12d771ce1fe6a43094c3d828caada4ed9a4540"


### PR DESCRIPTION
Hey, hey!  This is a VERY belated changeset (sorry) that just adds the normalizr version lock to master.